### PR TITLE
Add Document Authoring and UE definitions for insights block

### DIFF
--- a/blocks/insights/insights.css
+++ b/blocks/insights/insights.css
@@ -11,6 +11,9 @@
   /* Minimum chart plot height; the chart grows to fill the usage panel */
   --insights-chart-min-plot-height: 220px;
 
+  /* Keep paints and stacking contained so following dashboard sections are not covered */
+  position: relative;
+  z-index: 0;
   width: 100%;
 }
 
@@ -42,7 +45,6 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
-  height: 100%;
   background: #fff;
   border-radius: 16px;
   padding: 24px 28px;

--- a/component-definition.json
+++ b/component-definition.json
@@ -170,12 +170,23 @@
           "title": "Insights",
           "id": "insights",
           "plugins": {
+            "da": {
+              "rows": 1,
+              "columns": 1,
+              "fields": [
+                {
+                  "name": "note",
+                  "selector": "div>div>p"
+                }
+              ]
+            },
             "xwalk": {
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
                   "name": "Insights",
-                  "model": "insights"
+                  "model": "insights",
+                  "note": ""
                 }
               }
             }

--- a/component-models.json
+++ b/component-models.json
@@ -5005,7 +5005,16 @@
   },
   {
     "id": "insights",
-    "fields": []
+    "fields": [
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "note",
+        "label": "Author note",
+        "value": "",
+        "description": "Optional note in the document for authors. Usage charts and the insights list are populated from CRM data on the dashboard; you can leave this empty."
+      }
+    ]
   },
   {
     "id": "offer",

--- a/templates/dashboard/dashboard.css
+++ b/templates/dashboard/dashboard.css
@@ -118,10 +118,6 @@ body.dashboard .dashboard-kpis {
   margin-bottom: 30px;
 }
 
-body.dashboard .dashboard-fleet {
-  margin-bottom: 30px;
-}
-
 body.dashboard .insights-container {
   margin-bottom: 30px;
 }
@@ -325,6 +321,9 @@ body.dashboard .dashboard-offers .offer-cards > div > div > p:last-child a:hover
 
 /* 7. Fleet section — white card with rounded corners */
 body.dashboard .dashboard-fleet {
+  position: relative;
+  z-index: 1;
+  margin-bottom: 30px;
   background: #fff;
   border-radius: 16px;
   padding: 28px 32px;

--- a/ue/models/blocks/insights.json
+++ b/ue/models/blocks/insights.json
@@ -3,6 +3,7 @@
     {
       "title": "Insights",
       "id": "insights",
+      "model": "insights",
       "plugins": {
         "da": {
           "rows": 1,
@@ -13,16 +14,6 @@
               "selector": "div>div>p"
             }
           ]
-        },
-        "xwalk": {
-          "page": {
-            "resourceType": "core/franklin/components/block/v1/block",
-            "template": {
-              "name": "Insights",
-              "model": "insights",
-              "note": ""
-            }
-          }
         }
       }
     }
@@ -37,7 +28,7 @@
           "name": "note",
           "label": "Author note",
           "value": "",
-          "description": "Optional note in the document for authors. Usage charts and the insights list are populated from CRM data on the dashboard; you can leave this empty."
+          "description": "Optional note for authors. Usage charts and insights load from CRM data on the dashboard."
         }
       ]
     }


### PR DESCRIPTION
- Extend _insights.json with plugins.da (1x1 cell, note field) and xwalk template
- Add ue/models/blocks/insights.json for Universal Editor
- Regenerate merged component-definition.json and component-models.json

Made-with: Cursor

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--frescopa--aem-showcase.aem.live/
- After: https://<branch>--frescopa--aem-showcase.aem.live/
