### PR TITLE
Dashboard layout: KPI grid alignment, section headings, machine fleet polish

### DIFF
--- a/blocks/insights/insights.css
+++ b/blocks/insights/insights.css
@@ -25,8 +25,9 @@
 
 @media (width >= 900px) {
   .insights-layout {
+    /* 2:1 split; dashboard template overrides with a 6-col grid to match KPI card tracks */
     grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-    gap: 28px;
+    gap: 16px;
   }
 }
 
@@ -47,7 +48,7 @@
   min-height: 0;
   background: #fff;
   border-radius: 16px;
-  padding: 24px 28px;
+  padding: 28px 32px;
   box-shadow: 0 2px 8px rgb(0 0 0 / 6%);
 }
 
@@ -441,7 +442,7 @@
   .insights-usage,
   .insights-list-panel {
     height: auto;
-    padding: 20px 18px;
+    padding: 24px;
   }
 
   .insights-usage-header {

--- a/blocks/machine-fleet/machine-fleet.css
+++ b/blocks/machine-fleet/machine-fleet.css
@@ -1,12 +1,16 @@
 .machine-fleet {
   padding: 0;
+
+  /* Match blocks/insights/insights.css tab filters */
+  --machine-fleet-filter-text: #4a1515;
+  --machine-fleet-filter-active-bg: #f7efe6;
 }
 
 .machine-fleet-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 12px 20px;
   margin-bottom: 1.5rem;
   flex-wrap: wrap;
 }
@@ -20,36 +24,45 @@
 
 .machine-fleet-filters {
   display: flex;
-  gap: 0.25rem;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-end;
+  gap: 8px 28px;
+  margin: 0;
 }
 
 .machine-fleet-filter {
-  padding: 0.45rem 1rem;
-  border-radius: 10px;
+  margin: 0;
+  padding: 8px 16px;
   border: none;
+  border-radius: 9px;
   background: transparent;
-  font-family: roboto, sans-serif;
-  font-size: 0.9rem;
+  color: var(--machine-fleet-filter-text);
+  font-family: inherit;
+  font-size: 14px;
   font-weight: 500;
+  line-height: 1.2;
   cursor: pointer;
-  color: #4a1a1a;
-  transition: background 0.15s, color 0.15s;
-}
-
-.machine-fleet-filter:hover:not(:disabled) {
-  background: #f0e8df;
-}
-
-.machine-fleet-filter.active {
-  background: #f0e8df;
-  color: #4a1a1a;
+  transition: background 0.15s ease;
 }
 
 .machine-fleet-filter:disabled {
-  color: #c4c4c4;
+  color: color-mix(in srgb, var(--machine-fleet-filter-text) 35%, transparent);
   cursor: default;
+}
+
+.machine-fleet-filter:focus-visible {
+  outline: 2px solid var(--machine-fleet-filter-text);
+  outline-offset: 2px;
+}
+
+.machine-fleet-filter:hover:not(:disabled) {
+  background: rgb(247 239 230 / 50%);
+}
+
+.machine-fleet-filter.active {
+  background: var(--machine-fleet-filter-active-bg);
+  color: var(--machine-fleet-filter-text);
 }
 
 .machine-fleet-grid {
@@ -100,7 +113,7 @@
   padding: 0.35rem 1rem;
   border-radius: 10px;
   font-family: roboto, sans-serif;
-  font-size: 0.875rem;
+  font-size: 1.2rem;
   font-weight: 500;
   width: fit-content;
   margin-bottom: 0.25rem;

--- a/blocks/machine-fleet/machine-fleet.js
+++ b/blocks/machine-fleet/machine-fleet.js
@@ -85,7 +85,7 @@ export default async function decorate(block) {
   const { machineFleet, company } = data;
   const filters = buildFilters(machineFleet);
 
-  const title = document.createElement('h2');
+  const title = document.createElement('h3');
   title.className = 'machine-fleet-title';
   title.textContent = `${company} Machine Fleet`;
 

--- a/templates/dashboard/dashboard.css
+++ b/templates/dashboard/dashboard.css
@@ -2,9 +2,16 @@
    Dashboard template — all rules scoped to body.dashboard
    ============================================================ */
 
-/* 1. Page background */
+/* 1. Page background + dashboard spacing tokens */
 body.dashboard {
   background-color: #f8f2ea;
+  --dashboard-section-gap: 32px;
+  --dashboard-content-pad-x: 48px;
+  --dashboard-content-pad-y: 32px;
+  --dashboard-card-padding: 28px 32px;
+  --dashboard-card-radius: 16px;
+  /* Same gap as KPI row (flex) — insights row uses a 6-col grid: 4 card + 2 card widths */
+  --dashboard-kpi-gap: 16px;
 }
 
 /* 3. Hide the reddish announcement banner */
@@ -98,35 +105,130 @@ body.dashboard .dashboard-sidebar ul li a:hover {
 }
 
 body.dashboard .dashboard-content {
+  box-sizing: border-box;
+  display: flex;
   flex: 1;
+  flex-direction: column;
+  row-gap: var(--dashboard-section-gap);
   overflow: auto;
-  padding: 0 48px;
+  padding: var(--dashboard-content-pad-y) var(--dashboard-content-pad-x)
+    calc(var(--dashboard-content-pad-y) * 1.5);
 }
 
-/* Strip max-width constraints inside dashboard content */
+@media (width <= 599px) {
+  body.dashboard {
+    --dashboard-content-pad-x: 24px;
+    --dashboard-content-pad-y: 24px;
+  }
+}
+
+/*
+ * Override global main > .section margins/padding so sections share one rhythm
+ * (avoids double horizontal padding from main > .section > div + dashboard-content).
+ */
 body.dashboard .dashboard-content .section-container,
 body.dashboard .dashboard-content > .section {
-  max-width: unset;
+  max-width: none;
 }
 
-body.dashboard .dashboard-greeting {
-  margin-bottom: 30px;
+body.dashboard .dashboard-content > .section {
+  margin: 0;
+}
+
+body.dashboard .dashboard-content > .section > div {
+  max-width: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* Section headings (h3) — match .insights-panel-title */
+body.dashboard .insights .insights-panel-title,
+body.dashboard .machine-fleet .machine-fleet-title,
+body.dashboard .dashboard-offers h3 {
+  font-family: 'Roboto Condensed', Roboto, sans-serif;
+  font-size: 22px;
+  font-weight: 600;
+  font-stretch: condensed;
+  line-height: 1.2;
+  color: var(--frescopa-color-text);
+}
+
+body.dashboard .dashboard-offers h3 {
+  margin: 0 0 20px;
+}
+
+body.dashboard .machine-fleet .machine-fleet-header {
+  margin-bottom: 40px;
+}
+
+/*
+ * Insights row aligns to the KPI row: 6 equal tracks, usage = 4 tracks, list = 2 tracks,
+ * gap matches the space between KPI cards.
+ */
+@media (width >= 900px) {
+  body.dashboard .insights .insights-layout {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: var(--dashboard-kpi-gap);
+  }
+
+  body.dashboard .insights .insights-usage {
+    grid-column: span 4;
+  }
+
+  body.dashboard .insights .insights-list-panel {
+    grid-column: span 2;
+  }
+}
+
+@media (width <= 899px) {
+  body.dashboard .insights .insights-layout {
+    grid-template-columns: 1fr;
+  }
+
+  body.dashboard .insights .insights-usage,
+  body.dashboard .insights .insights-list-panel {
+    grid-column: auto;
+  }
+}
+
+/*
+ * Machine fleet cards: each row = two cards, each spans 3 of 6 KPI tracks (gap matches KPI row).
+ */
+@media (width >= 900px) {
+  body.dashboard .dashboard-fleet .machine-fleet-grid {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: var(--dashboard-kpi-gap);
+  }
+
+  body.dashboard .dashboard-fleet .machine-fleet-card {
+    grid-column: span 3;
+    min-width: 0;
+    max-width: none;
+    flex: unset;
+  }
+}
+
+@media (width <= 899px) {
+  body.dashboard .dashboard-fleet .machine-fleet-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--dashboard-kpi-gap);
+  }
+
+  body.dashboard .dashboard-fleet .machine-fleet-card {
+    grid-column: auto;
+    max-width: none;
+  }
 }
 
 /* 5. KPI cards — section class: dashboard-kpis (also supports legacy kpi-cards block class) */
-body.dashboard .dashboard-kpis {
-  margin-bottom: 30px;
-}
-
-body.dashboard .insights-container {
-  margin-bottom: 30px;
-}
 
 body.dashboard .dashboard-kpis .cards-wrapper .cards ul,
 body.dashboard .kpi-cards > .cards-wrapper > .cards > ul {
   display: flex;
   flex-wrap: nowrap;
-  gap: 16px;
+  gap: var(--dashboard-kpi-gap);
   grid-template-columns: unset;
   margin: 0;
   padding: 0;
@@ -196,9 +298,8 @@ body.dashboard .kpi-cards .cards-card-body > p:last-child {
 /* 6. Offers section */
 body.dashboard .dashboard-offers {
   background: #fff;
-  border-radius: 16px;
-  padding: 28px 32px;
-  margin-bottom: 30px;
+  border-radius: var(--dashboard-card-radius);
+  padding: var(--dashboard-card-padding);
 }
 
 /* Strip inner section wrappers */
@@ -207,15 +308,6 @@ body.dashboard .dashboard-offers > div {
   max-width: unset;
   margin: 0;
   padding: 0;
-
-  
-
-}
-
-/* Section heading */
-body.dashboard .dashboard-offers h3 {
-
-  margin: 0 0 20px;
 }
 
 /* Three-column grid of offer cards */
@@ -323,10 +415,9 @@ body.dashboard .dashboard-offers .offer-cards > div > div > p:last-child a:hover
 body.dashboard .dashboard-fleet {
   position: relative;
   z-index: 1;
-  margin-bottom: 30px;
   background: #fff;
-  border-radius: 16px;
-  padding: 28px 32px;
+  border-radius: var(--dashboard-card-radius);
+  padding: var(--dashboard-card-padding);
   box-shadow: 0 2px 8px rgb(0 0 0 / 6%);
 }
 


### PR DESCRIPTION
## Summary

Aligns dashboard sections with the KPI card row, unifies section `h3` typography with the insights block, and polishes the machine fleet block (grid, heading, filters).

## Changes

### `templates/dashboard/dashboard.css`
- Spacing tokens (`--dashboard-kpi-gap`, content padding, card padding)
- Flex column + `row-gap` on `.dashboard-content`; reset global section margins/padding
- Insights: 6-column grid (usage spans 4, list spans 2), 16px gap vs KPI row
- Machine fleet: 6-column grid (each card spans 3), responsive stack
- Shared section heading styles for `.insights-panel-title`, `.machine-fleet-title`, `.dashboard-offers h3`
- Machine fleet header spacing; consolidated offers wrapper rules

### `blocks/insights/insights.css`
- Desktop gap 16px; mobile panel padding

### `blocks/machine-fleet/`
- Section title `h3` (was `h2`)
- Filter row/buttons styled like insights tabs (gap, padding, colors, hover, active, focus)
- Header gap aligned with insights usage header

## Preview

Test on branch preview (replace with your branch URL):

`https://feature--dashboard-alignment-machine-fleet--frescopa--aem-showcase.aem.page/dashboard/`

(Adjust hostname to match your Edge Delivery repo naming.)

## Not included

- `drafts/` local files remain untracked.

Made with [Cursor](https://cursor.com)