### PR TITLE
Add DM video Block 

### DIFF
--- a/blocks/dm-video/_dm-video.json
+++ b/blocks/dm-video/_dm-video.json
@@ -1,0 +1,42 @@
+{
+  "definitions": [
+    {
+      "title": "DM Video",
+      "id": "dm-video",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block",
+            "template": {
+              "name": "DM Video",
+              "model": "dm-video",
+              "filter": "dm-video"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "dm-video",
+      "fields": [
+        {
+          "component": "reference",
+          "valueType": "string",
+          "name": "thumbnail",
+          "label": "Thumbnail / poster image",
+          "multi": false
+        },
+        {
+          "component": "text",
+          "valueType": "string",
+          "name": "videoUrl",
+          "label": "DM video URL (/play player or direct .mp4)",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "filters": []
+}

--- a/blocks/dm-video/dm-video.css
+++ b/blocks/dm-video/dm-video.css
@@ -1,0 +1,30 @@
+.dm-video.block {
+  display: block;
+}
+
+.dm-video .dm-video-player {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+  border-radius: 8px;
+  background: #000;
+}
+
+.dm-video .dm-video-iframe-wrap {
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  aspect-ratio: 16 / 9;
+  background: #000;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.dm-video .dm-video-iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}

--- a/blocks/dm-video/dm-video.js
+++ b/blocks/dm-video/dm-video.js
@@ -1,0 +1,145 @@
+/**
+ * Dynamic Media Open API video in Franklin:
+ * - `/play` URLs → Dynamic Media video player: embed with <iframe>, preserve full query string.
+ * - Direct progressive URLs (e.g. …/as/…mp4) → native <video>.
+ */
+
+function getFirstUrlFromText(text) {
+  if (!text) return '';
+  const match = text.match(/https?:\/\/[^\s<>"']+/i);
+  return match ? match[0] : '';
+}
+
+function getUrlFromRow(row) {
+  if (!row) return '';
+
+  const anchor = row.querySelector('a[href]');
+  if (anchor?.href) return anchor.href;
+
+  const source = row.querySelector('source[srcset]');
+  if (source?.srcset) {
+    const firstCandidate = source.srcset.split(',')[0]?.trim().split(/\s+/)[0];
+    if (firstCandidate) return firstCandidate;
+  }
+
+  const image = row.querySelector('img[src]');
+  if (image?.src) return image.src;
+
+  const video = row.querySelector('video[src]');
+  if (video?.src) return video.src;
+
+  return getFirstUrlFromText(row.textContent?.trim());
+}
+
+/**
+ * Prefer <picture><img> for poster — stable JPEG/PNG, not webp from first <source>.
+ * @param {Element | undefined} row
+ * @returns {string}
+ */
+function getPosterUrlFromRow(row) {
+  if (!row) return '';
+  const imgInPicture = row.querySelector('picture img[src]');
+  if (imgInPicture?.src) return imgInPicture.src;
+  return getUrlFromRow(row);
+}
+
+/**
+ * `/play` → iframe with full href. Direct media → native <video>.
+ * @param {string} rawUrl
+ * @returns {{ href: string, mode: 'progressive' | 'iframe' }}
+ */
+function resolveDmVideoDelivery(rawUrl) {
+  try {
+    const u = new URL(rawUrl, window.location.href);
+    const path = u.pathname;
+
+    if (/\/play\/?$/i.test(path) || path.endsWith('/play')) {
+      return { href: u.href, mode: 'iframe' };
+    }
+
+    if (path.includes('/as/') && /\.(mp4|webm|ogg|ogv)(\?|$)/i.test(path)) {
+      u.searchParams.delete('wid');
+      u.searchParams.delete('dpr');
+      u.searchParams.delete('resMode');
+      u.searchParams.delete('sdk');
+      return { href: u.href, mode: 'progressive' };
+    }
+
+    if (/\.(mp4|webm|ogg|ogv)(\?|$)/i.test(path)) {
+      return { href: u.href, mode: 'progressive' };
+    }
+
+    return { href: rawUrl, mode: 'progressive' };
+  } catch (e) {
+    return { href: rawUrl, mode: 'progressive' };
+  }
+}
+
+function getMimeTypeFromUrl(url) {
+  try {
+    const pathname = new URL(url, window.location.href).pathname.toLowerCase();
+    if (pathname.endsWith('.mp4')) return 'video/mp4';
+    if (pathname.endsWith('.webm')) return 'video/webm';
+    if (pathname.endsWith('.ogg') || pathname.endsWith('.ogv')) return 'video/ogg';
+  } catch (e) {
+    // Ignore
+  }
+  return '';
+}
+
+export default function decorate(block) {
+  const rows = [...block.children];
+  const thumbnailUrl = getPosterUrlFromRow(rows[0]);
+  const rawVideoUrl = getUrlFromRow(rows[1]);
+
+  if (!rawVideoUrl) {
+    return;
+  }
+
+  const { href: videoHref, mode } = resolveDmVideoDelivery(rawVideoUrl);
+
+  block.textContent = '';
+
+  if (mode === 'iframe') {
+    const wrap = document.createElement('div');
+    wrap.className = 'dm-video-iframe-wrap';
+    const iframe = document.createElement('iframe');
+    iframe.className = 'dm-video-iframe';
+    iframe.src = videoHref;
+    iframe.title = 'Video';
+    iframe.setAttribute('loading', 'lazy');
+    iframe.setAttribute('allowfullscreen', '');
+    iframe.setAttribute(
+      'allow',
+      'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
+    );
+    wrap.append(iframe);
+    block.append(wrap);
+    return;
+  }
+
+  const video = document.createElement('video');
+  video.className = 'dm-video-player';
+  video.controls = true;
+  video.preload = 'metadata';
+  video.playsInline = true;
+
+  if (thumbnailUrl) {
+    video.poster = thumbnailUrl;
+  }
+
+  const source = document.createElement('source');
+  source.src = videoHref;
+  const mimeType = getMimeTypeFromUrl(videoHref);
+  if (mimeType) source.type = mimeType;
+  video.append(source);
+
+  const fallback = document.createElement('p');
+  const fallbackLink = document.createElement('a');
+  fallbackLink.href = videoHref;
+  fallbackLink.textContent = 'View video';
+  fallback.append('Your browser does not support embedded videos. ', fallbackLink);
+  video.append(fallback);
+
+  block.append(video);
+}

--- a/component-definition.json
+++ b/component-definition.json
@@ -960,6 +960,38 @@
           }
         },
         {
+          "title": "Video",
+          "id": "video",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Video",
+                  "model": "video",
+                  "filter": "video"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "DM Video",
+          "id": "dm-video",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "DM Video",
+                  "model": "dm-video",
+                  "filter": "dm-video"
+                }
+              }
+            }
+          }
+        },
+        {
           "title": "Sticky CTA",
           "id": "sticky-cta",
           "plugins": {

--- a/component-filters.json
+++ b/component-filters.json
@@ -27,6 +27,7 @@
       "product-list-page-custom",
       "product-details",
       "video",
+      "dm-video",
       "form",
       "embed-adaptive-form",
       "reward",

--- a/component-models.json
+++ b/component-models.json
@@ -361,6 +361,25 @@
     ]
   },
   {
+    "id": "dm-video",
+    "fields": [
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "thumbnail",
+        "label": "Thumbnail / poster image",
+        "multi": false
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "videoUrl",
+        "label": "DM video URL (/play player or direct .mp4)",
+        "required": true
+      }
+    ]
+  },
+  {
     "id": "embed-adaptive-form",
     "fields": [
       {

--- a/models/_component-definition.json
+++ b/models/_component-definition.json
@@ -74,6 +74,12 @@
           "...": "../blocks/reward-sticky/_*.json#/definitions"
         },
         {
+          "...": "../blocks/video/_*.json#/definitions"
+        },
+        {
+          "...": "../blocks/dm-video/_*.json#/definitions"
+        },
+        {
           "...": "../blocks/sticky-cta/_*.json#/definitions"
         }
       ]

--- a/models/_section.json
+++ b/models/_section.json
@@ -94,6 +94,7 @@
         "product-list-page-custom",
         "product-details",
         "video",
+        "dm-video",
         "form",
         "embed-adaptive-form",
         "reward",

--- a/ue/models/blocks/dm-video.json
+++ b/ue/models/blocks/dm-video.json
@@ -1,0 +1,58 @@
+{
+  "definitions": [
+    {
+      "title": "DM Video",
+      "id": "dm-video",
+      "model": "dm-video",
+      "plugins": {
+        "da": {
+          "name": "dm-video",
+          "rows": 2,
+          "columns": 1,
+          "fields": [
+            {
+              "name": "thumbnail",
+              "selector": "div:nth-child(1) > div picture img[src]"
+            },
+            {
+              "name": "videoUrl",
+              "selector": "div:nth-child(2) > div a[href]"
+            },
+            {
+              "name": "videoUrlText",
+              "selector": "div:nth-child(2) > div a"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "dm-video",
+      "fields": [
+        {
+          "component": "reference",
+          "name": "thumbnail",
+          "label": "Thumbnail / poster image",
+          "valueType": "string",
+          "multi": false
+        },
+        {
+          "component": "text",
+          "name": "videoUrl",
+          "label": "DM video URL (/play or .mp4)",
+          "valueType": "string",
+          "required": true
+        },
+        {
+          "component": "text",
+          "name": "videoUrlText",
+          "label": "Video URL link text",
+          "valueType": "string"
+        }
+      ]
+    }
+  ],
+  "filters": []
+}

--- a/ue/models/section.json
+++ b/ue/models/section.json
@@ -49,6 +49,7 @@
         "table",
         "text",
         "video",
+        "dm-video",
         "product-recommendations"
       ]
     }


### PR DESCRIPTION
Added a DM video block to render video like https://delivery-p149891-e1546482.adobeaemcloud.com/adobe/assets/urn:aaid:aem:61cdedd5-afd5-49d3-a45b-1ad1b29e294a/play?languageselected=eng%2Cfra%2Cita&enableFeedback=true&autoplay=true&muted=true&customcss=https://s7d1.scene7.com/is/content/demodmcompany/summitdemo/frescopa_logo.css 

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): 



Fix #<gh-issue-id>

Test URLs:
- Before: https://main--frescopa--aem-showcase.aem.live/
- After: https://main--frescopa--aem-showcase.aem.live/ 
